### PR TITLE
Fix Vite config module resolution issue

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,23 +3,30 @@ import react from "@vitejs/plugin-react-swc";
 import themePlugin from "@replit/vite-plugin-shadcn-theme-json";
 import path, { dirname } from "path";
 import { fileURLToPath } from "url";
+import { createRequire } from "module";
 // PWA removed
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-export default defineConfig(async ({ mode }) => {
-	const devPlugins = [];
+
+export default defineConfig(({ mode }) => {
+	const plugins = [react(), themePlugin()];
+
 	if (mode === "development") {
-		const { default: runtimeErrorOverlay } = await import("@replit/vite-plugin-runtime-error-modal");
-		devPlugins.push(runtimeErrorOverlay());
+		const require = createRequire(import.meta.url);
+		try {
+			const mod = require("@replit/vite-plugin-runtime-error-modal");
+			const overlay = mod?.default ?? mod;
+			if (typeof overlay === "function") {
+				plugins.push(overlay());
+			}
+		} catch {
+			// Optional dev-only plugin not available; ignore on CI/Render.
+		}
 	}
 
 	return {
-		plugins: [
-			react(),
-			...devPlugins,
-			themePlugin(),
-		],
+		plugins,
 		resolve: {
 			alias: {
 				"@": path.resolve(__dirname, "client", "src"),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,55 +2,62 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import themePlugin from "@replit/vite-plugin-shadcn-theme-json";
 import path, { dirname } from "path";
-import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 import { fileURLToPath } from "url";
 // PWA removed
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-export default defineConfig(({ mode }) => ({
-	plugins: [
-		react(),
-		...(mode === 'development' ? [runtimeErrorOverlay()] : []),
-		themePlugin(),
-	],
-	resolve: {
-		alias: {
-			"@": path.resolve(__dirname, "client", "src"),
-			"@shared": path.resolve(__dirname, "shared"),
-		},
-	},
-	server: {
-		allowedHosts: true,
-		// Proxy API requests to the mock server during client-only development
-		proxy: {
-			"/api": {
-				target: "http://localhost:4000",
-				changeOrigin: true,
-				ws: false,
+export default defineConfig(async ({ mode }) => {
+	const devPlugins = [];
+	if (mode === "development") {
+		const { default: runtimeErrorOverlay } = await import("@replit/vite-plugin-runtime-error-modal");
+		devPlugins.push(runtimeErrorOverlay());
+	}
+
+	return {
+		plugins: [
+			react(),
+			...devPlugins,
+			themePlugin(),
+		],
+		resolve: {
+			alias: {
+				"@": path.resolve(__dirname, "client", "src"),
+				"@shared": path.resolve(__dirname, "shared"),
 			},
 		},
-	},
-	root: path.resolve(__dirname, "client"),
-	build: {
-		outDir: path.resolve(__dirname, "dist/public"),
-		emptyOutDir: true,
-		rollupOptions: {
-			output: {
-				manualChunks: {
-					vendor: ['react', 'react-dom'],
-					router: ['wouter'],
-					ui: ['@radix-ui/react-dialog', '@radix-ui/react-dropdown-menu', '@radix-ui/react-tabs'],
-					charts: ['chart.js', 'react-chartjs-2'],
-					forms: ['react-hook-form', '@hookform/resolvers'],
-					utils: ['date-fns', 'clsx', 'class-variance-authority'],
-					markdown: ['react-markdown', 'remark-gfm'],
-					animations: ['framer-motion']
+		server: {
+			allowedHosts: true,
+			// Proxy API requests to the mock server during client-only development
+			proxy: {
+				"/api": {
+					target: "http://localhost:4000",
+					changeOrigin: true,
+					ws: false,
+				},
+			},
+		},
+		root: path.resolve(__dirname, "client"),
+		build: {
+			outDir: path.resolve(__dirname, "dist/public"),
+			emptyOutDir: true,
+			rollupOptions: {
+				output: {
+					manualChunks: {
+					 vendor: ['react', 'react-dom'],
+					 router: ['wouter'],
+					 ui: ['@radix-ui/react-dialog', '@radix-ui/react-dropdown-menu', '@radix-ui/react-tabs'],
+					 charts: ['chart.js', 'react-chartjs-2'],
+					 forms: ['react-hook-form', '@hookform/resolvers'],
+					 utils: ['date-fns', 'clsx', 'class-variance-authority'],
+					 markdown: ['react-markdown', 'remark-gfm'],
+					 animations: ['framer-motion']
+					}
 				}
 			}
+		},
+		esbuild: {
+			drop: mode === "production" ? ["console", "debugger"] : []
 		}
-	},
-	esbuild: {
-		drop: mode === 'production' ? ['console', 'debugger'] : []
-	}
-}));
+	};
+});


### PR DESCRIPTION
This pull request modifies the Vite configuration in `vite.config.ts` to dynamically import the `@replit/vite-plugin-runtime-error-modal` only in development mode. This change addresses the build error related to the module not being found, allowing the project to successfully build on Render. Additionally, the overall structure of the configuration remains intact, ensuring that all necessary plugins are included without causing build failures.

---

> This pull request was co-created with Cosine Genie

Original Task: [Bubbles-cafe/sqo16ahvaf1s](https://cosine.sh/i9uifo5yrsyv/Bubbles-cafe/task/sqo16ahvaf1s)
Author: vantalison
