### PR TITLE
Fix server start command to resolve build and deployment issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:client": "vite --host",
     "dev:server": "tsx server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist --minify --drop:console --drop:debugger && node scripts/generate-icons.js && node scripts/generate-sitemaps.mjs",
-    "start": "node dist/index.js",
+    "start": "cross-env NODE_ENV=production tsx server/index.ts",
     "check": "tsc",
     "check:watch": "tsc --watch",
     "db:generate": "drizzle-kit generate:pg",


### PR DESCRIPTION
This pull request updates the `start` script in `package.json` from `node dist/index.js` to `cross-env NODE_ENV=production tsx server/index.ts`. This change ensures that the server runs correctly in production mode. The previous command failed during deployment, as indicated by the logs related to the application exiting early due to missing environment variables. This fix aims to stabilize the deployment process on Vercel.

---

> This pull request was co-created with Cosine Genie

Original Task: [Bubbles-cafe/32ry1yqjtjwx](https://cosine.sh/i9uifo5yrsyv/Bubbles-cafe/task/32ry1yqjtjwx)
Author: vantalison
